### PR TITLE
this is a very old fix, I do not know how it is missing in this one repo

### DIFF
--- a/dashboard/modules/@apostrophecms/image/index.js
+++ b/dashboard/modules/@apostrophecms/image/index.js
@@ -1,8 +1,0 @@
-export default {
-  fields: {
-    remove: [ '_tags' ]
-  },
-  filters: {
-    remove: [ '_tags' ]
-  }
-};


### PR DESCRIPTION
OK it looks like the fix just never made it here, it's not in the git history previously.

media library cannot work without this relationship