### PR TITLE
palette works 100% with footer in dev environment

### DIFF
--- a/sites/modules/@apostrophecms-pro/palette/lib/configs/5footer.js
+++ b/sites/modules/@apostrophecms-pro/palette/lib/configs/5footer.js
@@ -3,7 +3,7 @@ const config = {
     footerBgColor: {
       label: 'Background color',
       type: 'color',
-      selector: '.footer',
+      selector: 'body .footer',
       property: 'background-color'
     },
     footerTextColor: {
@@ -25,7 +25,7 @@ const config = {
     footerPadding: {
       label: 'Vertical padding',
       type: 'range',
-      selector: '.footer',
+      selector: 'body .footer',
       unit: 'px',
       property: [
         'padding-top',


### PR DESCRIPTION
This is a workaround for:

https://linear.app/apostrophecms/issue/PRO-7885/fix-order-of-palette-and-vite-assets

And can go away when we get to releasing that fix.